### PR TITLE
Nissix plugin scope-packages on wix-ui-tpa-connected

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -548,6 +548,45 @@
         "@xtuc/long": "4.2.2"
       }
     },
+    "@wix/wix-ui-tpa-analyser": {
+      "version": "1.0.0",
+      "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/@wix/wix-ui-tpa-analyser/-/@wix/wix-ui-tpa-analyser-1.0.0.tgz",
+      "integrity": "sha1-0WTBbjIBoIPGsgRMzBmo21tldU8=",
+      "requires": {
+        "args": "~5.0.1",
+        "find-node-modules": "^2.0.0",
+        "json-beautify": "^1.1.0"
+      }
+    },
+    "@wix/wix-ui-tpa-connected-generator": {
+      "version": "2.0.1",
+      "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/@wix/wix-ui-tpa-connected-generator/-/@wix/wix-ui-tpa-connected-generator-2.0.1.tgz",
+      "integrity": "sha1-geASF8C3jHSxHhilb5RRDhD9T74=",
+      "dev": true,
+      "requires": {
+        "@stylable/webpack-plugin": "^1.1.4",
+        "@types/css-tree": "^1.0.0",
+        "@types/ejs": "^2.6.3",
+        "@types/mkdirp": "^0.5.2",
+        "@types/react": "^16.8.16",
+        "@types/rimraf": "^2.0.2",
+        "@types/uniqid": "^4.1.3",
+        "args": "^5.0.1",
+        "css-tree": "^1.0.0-alpha.29",
+        "ejs": "^2.6.1",
+        "find-node-modules": "^2.0.0",
+        "json-beautify": "^1.1.0",
+        "mkdirp": "^0.5.1",
+        "react": "^16.8.6",
+        "retry-cli": "^0.6.0",
+        "rimraf": "^2.6.3",
+        "uniqid": "^5.0.3",
+        "webpack": "^4.29.6",
+        "webpack-cli": "^3.3.0",
+        "webpack-node-externals": "^1.7.2",
+        "wix-ui-tpa-analyser": "^1.0.0"
+      }
+    },
     "@xtuc/ieee754": {
       "version": "1.2.0",
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
@@ -6995,39 +7034,11 @@
       "version": "1.0.0",
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/wix-ui-tpa-analyser/-/wix-ui-tpa-analyser-1.0.0.tgz",
       "integrity": "sha1-AHzfwIch3V8CbOVTFEWo0Fz5Bks=",
+      "dev": true,
       "requires": {
         "args": "~5.0.1",
         "find-node-modules": "^2.0.0",
         "json-beautify": "^1.1.0"
-      }
-    },
-    "wix-ui-tpa-connected-generator": {
-      "version": "2.0.1",
-      "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/wix-ui-tpa-connected-generator/-/wix-ui-tpa-connected-generator-2.0.1.tgz",
-      "integrity": "sha1-8mPs//W6NsrKbvbgRfd9XjmICWI=",
-      "dev": true,
-      "requires": {
-        "@stylable/webpack-plugin": "^1.1.4",
-        "@types/css-tree": "^1.0.0",
-        "@types/ejs": "^2.6.3",
-        "@types/mkdirp": "^0.5.2",
-        "@types/react": "^16.8.16",
-        "@types/rimraf": "^2.0.2",
-        "@types/uniqid": "^4.1.3",
-        "args": "^5.0.1",
-        "css-tree": "^1.0.0-alpha.29",
-        "ejs": "^2.6.1",
-        "find-node-modules": "^2.0.0",
-        "json-beautify": "^1.1.0",
-        "mkdirp": "^0.5.1",
-        "react": "^16.8.6",
-        "retry-cli": "^0.6.0",
-        "rimraf": "^2.6.3",
-        "uniqid": "^5.0.3",
-        "webpack": "^4.29.6",
-        "webpack-cli": "^3.3.0",
-        "webpack-node-externals": "^1.7.2",
-        "wix-ui-tpa-analyser": "^1.0.0"
       }
     },
     "worker-farm": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "license": "MIT",
   "homepage": "https://github.com/wix-playground/wix-ui-tpa-connected",
   "dependencies": {
-    "wix-ui-tpa-analyser": "^1.0.0"
+    "@wix/wix-ui-tpa-analyser": "^1.0.0"
   },
   "devDependencies": {
     "@stylable/webpack-plugin": "^1.1.4",
@@ -45,7 +45,7 @@
     "webpack": "^4.31.0",
     "webpack-cli": "^3.3.2",
     "wix-ui-tpa": "^2.1.1",
-    "wix-ui-tpa-connected-generator": "^2.0.1"
+    "@wix/wix-ui-tpa-connected-generator": "^2.0.1"
   },
   "publishConfig": {}
 }


### PR DESCRIPTION
Hi, I'm Nissix, the automated PR bot!

Wix is moving its internal packages to the @wix scope (but still in the internal registry). Publishing new unscoped internal packages is no longer allowed, and all existing packages are moving to @wix. This means changing package names, and also all usages of those packages to their @wix scope version.

This PR is an automatic codemod that moves all of your packages to @wix scope, and changes any usages (`pacakge.json`, imports, requires, etc..) to their @wix version.

| :bangbang: | This codemod is best-effort! Meaning it may not have found and fixed all usages, but it did change your package.jsons. So go over the changes carefully and test this version carefully  |
| :--------: | :----------------------------------------------------------------------------------------------------- |

If you want to know why we don't support publishing unscoped to the internal registry, check out this article on [Dependency Confusion](https://medium.com/@alex.birsan/dependency-confusion-4a5d60fec610)

If you are unsure, need help or have questions, reach us at #wix-scope-migration

Error Log:
npx: installed 234 in 7.069s



Output Log:
Migrating package "wix-ui-tpa-connected" in .


## Migration from non scope to @wix/scoped packages
> /tmp/d5c46a36ef6bede10826916318e801de

#### rename package.json dependencies/dev/bundled/peer/optional, jest & eslintConfig
```
package.json
```
added 35 packages from 43 contributors and audited 798 packages in 4.093s

1 package is looking for funding
  run `npm fund` for details

found 11 vulnerabilities (8 low, 3 high)
  run `npm audit fix` to fix them, or `npm audit` for details

